### PR TITLE
[PKG-4491] pykrb5 0.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/k/krb5/krb5-{{ version }}.tar.gz
   sha256: 7125ee240dad951cc0a71e567c51b215238e490e87ad67b1af9a69dd90e63bca
+  patches:
+    - use-krb5-instead-of-heimdal-framework.patch
 
 build:
   number: 0
@@ -15,15 +17,17 @@ build:
   # '"krb5-config --cflags krb5" is not recognized as an internal or external command'
   skip: true  # [py<37 or win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  missing_dso_whitelist:  # [osx]
+  #missing_dso_whitelist:  # [osx]
     # pykrb5 requires Heimdal on MacOS
     # see https://github.com/jborean93/pykrb5/blob/v0.5.1/README.md#installation 
     # and https://github.com/jborean93/pykrb5/blob/v0.5.1/setup.py#L181-L182
-    - /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal  # [osx]
+    #- /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal  # [osx]
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - patch     # [unix]
+    - m2-patch  # [win]
   host:
     - cython >=0.29.32,<4.0.0
     - krb5 1.20
@@ -50,6 +54,9 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_kt_read_service_key_multiple_kvno or test_kt_read_service_key_multiple_enctype or test_kt_client_default" %}
 {% set tests_to_skip = tests_to_skip + " or test_parse_principal or test_parse_principal_no_realm_failure or test_unparse_principal" %}
 {% set tests_to_skip = tests_to_skip + " or test_enctype_to_string or test_enctype_to_string_invalid or test_string_to_enctype_invalid or test_get_init_creds_keytab" %}
+# After using conda's krb5 instead of macOS's private krb5 framework, macOS doesn't support the DIR type so this returns False,
+# see https://github.com/jborean93/pykrb5/blob/v0.5.1/tests/test_ccache.py#L222
+{% set tests_to_skip = tests_to_skip + " or test_cc_supports_switch" %}  # [osx]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,6 @@ build:
   # '"krb5-config --cflags krb5" is not recognized as an internal or external command'
   skip: true  # [py<37 or win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  #missing_dso_whitelist:  # [osx]
-    # pykrb5 requires Heimdal on MacOS
-    # see https://github.com/jborean93/pykrb5/blob/v0.5.1/README.md#installation 
-    # and https://github.com/jborean93/pykrb5/blob/v0.5.1/setup.py#L181-L182
-    #- /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal  # [osx]
 
 requirements:
   build:
@@ -36,7 +31,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - krb5 >=1.20.1,<1.21.0a0
+    - krb5
     - python
 
 # The tests fail because of the error "FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/kdb5_util'".

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [win or py<37]
+  skip: true  # [py<37]
 
 requirements:
   build:
@@ -25,8 +25,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - cryptography >=1.3
-    - krb5
+    - krb5 >=1.20.1,<1.21.0a0
     - python
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,16 @@ source:
   sha256: 7125ee240dad951cc0a71e567c51b215238e490e87ad67b1af9a69dd90e63bca
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   # pykrb5 isn't supported on win64, it fails because of an error:
   # '"krb5-config --cflags krb5" is not recognized as an internal or external command'
   skip: true  # [py<37 or win]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  missing_dso_whitelist:  # [osx]
+    # pykrb5 requires Heimdal on MacOS
+    # see https://github.com/jborean93/pykrb5/blob/v0.5.1/README.md#installation 
+    # and https://github.com/jborean93/pykrb5/blob/v0.5.1/setup.py#L181-L182
+    - /System/Library/PrivateFrameworks/Heimdal.framework/Versions/A/Heimdal  # [osx]
 
 requirements:
   build:
@@ -30,13 +35,35 @@ requirements:
     - krb5 >=1.20.1,<1.21.0a0
     - python
 
+# The tests fail because of the error "FileNotFoundError: [Errno 2] No such file or directory: '/usr/sbin/kdb5_util'".
+# The real location of kdb5_util is $PREFIX/sbin not /usr/sbin but it's hardcoded in the k5test's source code,
+# see https://github.com/pythongssapi/k5test/blob/17512bd2137ffcdd1fdb7ff4210891ad34d27803/k5test/realm.py#L459
+{% set tests_to_skip = "_not_a_real_test" %}
+{% set tests_to_skip = tests_to_skip + " or test_cc_default or test_cc_default_name or test_cc_store_cred" %}
+{% set tests_to_skip = tests_to_skip + " or test_cc_switch or test_cc_cache_match or test_cc_retrieve_remove_cred" %}
+{% set tests_to_skip = tests_to_skip + " or test_set_default_realm or :test_get_init_creds_keytab or test_get_init_creds_password" %}
+{% set tests_to_skip = tests_to_skip + " or test_get_init_creds_password_prompt or test_get_init_creds_password_prompt_failure or test_get_creds_keytab" %}
+{% set tests_to_skip = tests_to_skip + " or test_get_creds_keytab_wrong_principal or test_init_creds_set_password or test_init_creds_set_password_invalid" %}
+{% set tests_to_skip = tests_to_skip + " or test_kt_default or test_kt_default_name or test_kt_get_name" %}
+{% set tests_to_skip = tests_to_skip + " or test_kt_enumerate or test_kt_get_entry_empty or test_kt_get_entry" %}
+{% set tests_to_skip = tests_to_skip + " or test_kt_get_entry_multiple_kvno or test_kt_get_entry_multiple_enctype or test_kt_read_service_key_empty" %}
+{% set tests_to_skip = tests_to_skip + " or test_kt_read_service_key_multiple_kvno or test_kt_read_service_key_multiple_enctype or test_kt_client_default" %}
+{% set tests_to_skip = tests_to_skip + " or test_parse_principal or test_parse_principal_no_realm_failure or test_unparse_principal" %}
+{% set tests_to_skip = tests_to_skip + " or test_enctype_to_string or test_enctype_to_string_invalid or test_string_to_enctype_invalid or test_get_init_creds_keytab" %}
+
 test:
+  source_files:
+    - tests
+    - stubs/k5test
   imports:
     - krb5
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pip install k5test
+    - pytest -v -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/jborean93/pykrb5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,23 +11,19 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
-  skip: true  # [win]
+  number: 0
+  skip: true  # [win or py<37]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - cython                                 # [build_platform != target_platform]
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
-    - krb5
-    - python
     - cython >=0.29.32,<4.0.0
-    - setuptools >=42.0.0
+    - krb5 1.20
     - pip
+    - python
+    - setuptools
+    - wheel
   run:
     - cryptography >=1.3
     - krb5
@@ -36,15 +32,19 @@ requirements:
 test:
   imports:
     - krb5
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/jborean93/pykrb5
+  dev_url: https://github.com/jborean93/pykrb5
+  doc_url: https://github.com/jborean93/pykrb5
   summary: Kerberos API bindings for Python
+  description: Kerberos API bindings for Python
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,9 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  skip: true  # [py<37]
+  # pykrb5 isn't supported on win64, it fails because of an error:
+  # '"krb5-config --cflags krb5" is not recognized as an internal or external command'
+  skip: true  # [py<37 or win]
 
 requirements:
   build:

--- a/recipe/use-krb5-instead-of-heimdal-framework.patch
+++ b/recipe/use-krb5-instead-of-heimdal-framework.patch
@@ -1,0 +1,31 @@
+diff --git a/setup.py b/setup.py
+index 1d27cf9..66e4d9e 100755
+--- a/setup.py
++++ b/setup.py
+@@ -125,10 +125,12 @@ def get_krb5_lib_path(
+     elif not krb5_lib:
+         for opt in libraries:
+             if opt.startswith("krb5"):
+-                ext = {
+-                    "nt": "dll",
+-                    "darwin": "dylib",
+-                }.get(os.name, "so")
++                if os.name == "nt":
++                    ext = "dll"
++                elif sys.platform == "darwin":
++                    ext = "dylib"
++                else:
++                    ext = "so"
+ 
+                 krb5_lib = f"lib{opt}.{ext}"
+                 break
+@@ -159,9 +161,6 @@ if not SKIP_EXTENSIONS:
+     print(f"Using krb5-config at '{kc}'")
+ 
+     macos_native = False
+-    if sys.platform == "darwin":
+-        mac_ver = [int(v) for v in platform.mac_ver()[0].split(".")]
+-        macos_native = mac_ver >= [10, 7, 0]
+ 
+     compile_args, raw_link_args = [
+         shlex.split(os.environ[e], posix=True) if e in os.environ else None


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4491](https://anaconda.atlassian.net/browse/PKG-4491)
- release-notes: https://github.com/jborean93/pykrb5/releases
- release-notes-tagged: https://github.com/jborean93/pykrb5/releases/tag/v0.5.1
- changelog: https://github.com/jborean93/pykrb5/blob/main/CHANGELOG.md
- license: https://github.com/jborean93/pykrb5/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/jborean93/pykrb5/blob/v0.5.1/pyproject.toml
  - https://github.com/jborean93/pykrb5/blob/v0.5.1/setup.cfg
  - https://github.com/jborean93/pykrb5/blob/v0.5.1/setup.py

### Explanation of changes:

- Forked/cloned conda-forge's recipe
- Skip win because of an error: `"krb5-config --cflags krb5" is not recognized as an internal or external command`
- Skip `py<37`
- Reset the build number
- Pin `krb5` to `1.20` in host and `krb5 >=1.20.1,<1.21.0a0` in `run`
- Remove `cryptography` as it's not mentioned in the source code
- Add dev & doc urls
- Add `license_family`
- Add `description`

[PKG-4491]: https://anaconda.atlassian.net/browse/PKG-4491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ